### PR TITLE
process_subscription additional fields should be saved under order meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .project
 .buildpath
 /.settings/

--- a/woo-payzen-payment/includes/subscriptions/payzen-wc-subscriptions-subscriptions-handler.php
+++ b/woo-payzen-payment/includes/subscriptions/payzen-wc-subscriptions-subscriptions-handler.php
@@ -195,14 +195,14 @@ class Payzen_WC_Subscriptions_Subscriptions_Handler implements Payzen_Subscripti
         $subscriptions = wcs_get_subscriptions_for_order($order);
         $subscription = reset($subscriptions); // Get first subscription.
 
-        delete_post_meta($subscription->get_id(), 'Subscription ID');
-        delete_post_meta($subscription->get_id(), 'Subscription amount');
-        delete_post_meta($subscription->get_id(), 'Effect date');
+        delete_post_meta($order->get_id(), 'Subscription ID');
+        delete_post_meta($order->get_id(), 'Subscription amount');
+        delete_post_meta($order->get_id(), 'Effect date');
 
         // Store subscription details.
-        update_post_meta($subscription->get_id(), 'Subscription ID', $response->get('subscription'));
-        update_post_meta($subscription->get_id(), 'Subscription amount', WC_Gateway_Payzen::display_amount($response->get('sub_amount'), $response->get('sub_currency')));
-        update_post_meta($subscription->get_id(), 'Effect date', preg_replace('#^(\d{4})(\d{2})(\d{2})$#', '\1-\2-\3', $response->get('sub_effect_date')));
+        update_post_meta($order->get_id(), 'Subscription ID', $response->get('subscription'));
+        update_post_meta($order->get_id(), 'Subscription amount', WC_Gateway_Payzen::display_amount($response->get('sub_amount'), $response->get('sub_currency')));
+        update_post_meta($order->get_id(), 'Effect date', preg_replace('#^(\d{4})(\d{2})(\d{2})$#', '\1-\2-\3', $response->get('sub_effect_date')));
 
         if (WC_Gateway_Payzen::is_successful_action($response)) {
             $subscription->payment_complete();


### PR DESCRIPTION
I have been working for a client and noticed that on process_subscription you are saving records in subscription metadata and getting the record for the subscription update or cancel through order metadata. It was throwing an exception. Here is a screenshot https://capture.dropbox.com/bBEsG3zvlWq7KEb7 of getting records from order metadata. Although you are saving it against a subscription https://capture.dropbox.com/rS1weeSI7GU7gp6T. 